### PR TITLE
Add 2 methods + finer checks on invalid input for alarms

### DIFF
--- a/src/ds323x/alarms.rs
+++ b/src/ds323x/alarms.rs
@@ -2,6 +2,7 @@
 
 use super::super::{BitFlags, Ds323x, Error, Hours, Register};
 use super::{decimal_to_packed_bcd, hours_to_register};
+use crate::ds323x::{NaiveTime, Timelike};
 use interface::{ReadData, WriteData};
 
 /// Parameters for setting Alarm1 on a day of the month
@@ -195,6 +196,20 @@ where
         self.iface.write_data(&mut data)
     }
 
+    /// Set Alarm1 for a time (fires when hours, minutes and seconds match).
+    ///
+    /// Will return an `Error::InvalidInputData` if any of the parameters is out of range.
+    /// day is not used by the matching strategy but is set to 1.
+    pub fn set_alarm1_hms(&mut self, when: NaiveTime) -> Result<(), Error<CommE, PinE>> {
+        let alarm = DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(when.hour() as u8),
+            minute: when.minute() as u8,
+            second: when.second() as u8,
+        };
+        self.set_alarm1_day(alarm, Alarm1Matching::HoursMinutesAndSecondsMatch)
+    }
+
     /// Set Alarm1 for weekday.
     ///
     /// Will return an `Error::InvalidInputData` if any of the used parameters
@@ -272,6 +287,19 @@ where
             decimal_to_packed_bcd(day) | match_mask[2],
         ];
         self.iface.write_data(&mut data)
+    }
+
+    /// Set Alarm2 for a time (fires when hours, minutes and seconds match).
+    ///
+    /// Will return an `Error::InvalidInputData` if any of the parameters is out of range.
+    /// day is not used by the matching strategy but is set to 1.
+    pub fn set_alarm2_hm(&mut self, when: NaiveTime) -> Result<(), Error<CommE, PinE>> {
+        let alarm = DayAlarm2 {
+            day: 1,
+            hour: Hours::H24(when.hour() as u8),
+            minute: when.minute() as u8,
+        };
+        self.set_alarm2_day(alarm, Alarm2Matching::HoursAndMinutesMatch)
     }
 
     /// Set Alarm2 for weekday.

--- a/tests/alarms.rs
+++ b/tests/alarms.rs
@@ -8,7 +8,7 @@ use common::{
 };
 extern crate ds323x;
 use ds323x::{
-    Alarm1Matching as A1M, Alarm2Matching as A2M, DayAlarm1, DayAlarm2, Error, Hours,
+    Alarm1Matching as A1M, Alarm2Matching as A2M, DayAlarm1, DayAlarm2, Error, Hours, NaiveTime,
     WeekdayAlarm1, WeekdayAlarm2,
 };
 
@@ -635,7 +635,13 @@ mod alarm1_day {
         },
         A1M::AllMatch
     );
-
+    set_alarm_test!(
+        match_hms_naivetime,
+        set_alarm1_hms,
+        ALARM1_SECONDS,
+        [4, 3, 2, AM | 1],
+        NaiveTime::from_hms(2, 3, 4)
+    );
     set_alarm_test!(
         match_hms,
         set_alarm1_day,
@@ -914,7 +920,13 @@ mod alarm2_day {
         },
         A2M::AllMatch
     );
-
+    set_alarm_test!(
+        match_hm_naivetime,
+        set_alarm2_hm,
+        ALARM2_MINUTES,
+        [3, 2, AM | 1],
+        NaiveTime::from_hms(2, 3, 0)
+    );
     set_alarm_test!(
         match_hm,
         set_alarm2_day,

--- a/tests/alarms.rs
+++ b/tests/alarms.rs
@@ -14,18 +14,18 @@ use ds323x::{
 
 #[macro_export]
 macro_rules! _set_invalid_alarm_test {
-    ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $alarm:expr, $matching:expr) => {
+    ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $( $value:expr ),+) => {
         #[test]
         fn $name() {
             let mut dev = $create_method(&[]);
-            assert_invalid_input_data!(dev.$method($alarm, $matching));
+            assert_invalid_input_data!(dev.$method($($value),*));
             $destroy_method(dev);
         }
     };
 }
 
 macro_rules! set_invalid_alarm_test {
-    ($name:ident, $method:ident, $alarm:expr, $matching:expr) => {
+    ($name:ident, $method:ident, $( $value:expr ),+) => {
         mod $name {
             use super::*;
             _set_invalid_alarm_test!(
@@ -33,24 +33,21 @@ macro_rules! set_invalid_alarm_test {
                 $method,
                 new_ds3231,
                 destroy_ds3231,
-                $alarm,
-                $matching
+                $($value),*
             );
             _set_invalid_alarm_test!(
                 cannot_set_invalid_ds3232,
                 $method,
                 new_ds3232,
                 destroy_ds3232,
-                $alarm,
-                $matching
+                $($value),*
             );
             _set_invalid_alarm_test!(
                 cannot_set_invalid_ds3234,
                 $method,
                 new_ds3234,
                 destroy_ds3234,
-                $alarm,
-                $matching
+                $($value),*
             );
         }
     };
@@ -81,6 +78,28 @@ mod alarm1 {
         A1M::AllMatch
     );
     set_invalid_alarm_test!(
+        day_invalid_second,
+        set_alarm1_day,
+        DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(1),
+            minute: 59,
+            second: 60
+        },
+        A1M::SecondsMatch
+    );
+    set_invalid_alarm_test!(
+        day_invalid_minute,
+        set_alarm1_day,
+        DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(1),
+            minute: 60,
+            second: 10
+        },
+        A1M::MinutesAndSecondsMatch
+    );
+    set_invalid_alarm_test!(
         day_invalid_h,
         set_alarm1_day,
         DayAlarm1 {
@@ -90,6 +109,17 @@ mod alarm1 {
             second: 1
         },
         A1M::AllMatch
+    );
+    set_invalid_alarm_test!(
+        day_invalid_h_hmasm,
+        set_alarm1_day,
+        DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(24),
+            minute: 1,
+            second: 1
+        },
+        A1M::HoursMinutesAndSecondsMatch
     );
     set_invalid_alarm_test!(
         day_invalid_am1,
@@ -192,6 +222,18 @@ mod alarm1 {
         A1M::AllMatch
     );
     set_invalid_alarm_test!(
+        wd_invalid_h_hmasm,
+        set_alarm1_weekday,
+        WeekdayAlarm1 {
+            weekday: 1,
+            hour: Hours::H24(24),
+            minute: 1,
+            second: 1
+        },
+        A1M::HoursMinutesAndSecondsMatch
+    );
+
+    set_invalid_alarm_test!(
         wd_invalid_am1,
         set_alarm1_weekday,
         WeekdayAlarm1 {
@@ -257,10 +299,42 @@ mod alarm1 {
         },
         A1M::AllMatch
     );
+    set_invalid_alarm_test!(
+        wd_invalid_sec_sm,
+        set_alarm1_weekday,
+        WeekdayAlarm1 {
+            weekday: 1,
+            hour: Hours::H24(1),
+            minute: 1,
+            second: 60
+        },
+        A1M::SecondsMatch
+    );
+    set_invalid_alarm_test!(
+        wd_invalid_min_masm,
+        set_alarm1_weekday,
+        WeekdayAlarm1 {
+            weekday: 1,
+            hour: Hours::H24(1),
+            minute: 60,
+            second: 1
+        },
+        A1M::MinutesAndSecondsMatch
+    );
 }
 
 mod alarm2 {
     use super::*;
+    set_invalid_alarm_test!(
+        day_invalid_min_mm,
+        set_alarm2_day,
+        DayAlarm2 {
+            day: 1,
+            hour: Hours::H24(1),
+            minute: 60
+        },
+        A2M::MinutesMatch
+    );
     set_invalid_alarm_test!(
         day_invalid_min,
         set_alarm2_day,
@@ -280,6 +354,16 @@ mod alarm2 {
             minute: 1
         },
         A2M::AllMatch
+    );
+    set_invalid_alarm_test!(
+        day_invalid_h_hamm,
+        set_alarm2_day,
+        DayAlarm2 {
+            day: 1,
+            hour: Hours::H24(24),
+            minute: 1
+        },
+        A2M::HoursAndMinutesMatch
     );
     set_invalid_alarm_test!(
         day_invalid_am1,
@@ -343,6 +427,16 @@ mod alarm2 {
     );
 
     set_invalid_alarm_test!(
+        wd_invalid_min_mm,
+        set_alarm2_weekday,
+        WeekdayAlarm2 {
+            weekday: 1,
+            hour: Hours::H24(1),
+            minute: 60
+        },
+        A2M::MinutesMatch
+    );
+    set_invalid_alarm_test!(
         wd_invalid_min,
         set_alarm2_weekday,
         WeekdayAlarm2 {
@@ -361,6 +455,16 @@ mod alarm2 {
             minute: 1
         },
         A2M::AllMatch
+    );
+    set_invalid_alarm_test!(
+        wd_invalid_h_hmm,
+        set_alarm2_weekday,
+        WeekdayAlarm2 {
+            weekday: 1,
+            hour: Hours::H24(24),
+            minute: 1
+        },
+        A2M::HoursAndMinutesMatch
     );
     set_invalid_alarm_test!(
         wd_invalid_am1,
@@ -422,22 +526,32 @@ mod alarm2 {
         },
         A2M::AllMatch
     );
+    set_invalid_alarm_test!(
+        wd_invalid_minute,
+        set_alarm2_weekday,
+        WeekdayAlarm2 {
+            weekday: 1,
+            hour: Hours::H24(1),
+            minute: 60
+        },
+        A2M::HoursAndMinutesMatch
+    );
 }
 
 macro_rules! _set_values_test {
-    ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $value1:expr, $value2:expr, $transactions:expr) => {
+    ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $transactions:expr, $( $value:expr ),+) => {
         #[test]
         fn $name() {
             let trans = $transactions;
             let mut dev = $create_method(&trans);
-            dev.$method($value1, $value2).unwrap();
+            dev.$method($($value),*).unwrap();
             $destroy_method(dev);
         }
     };
 }
 
 macro_rules! set_values_test {
-    ($name:ident, $method:ident, $value1:expr, $value2:expr, $i2c_transactions:expr, $spi_transactions:expr) => {
+    ($name:ident, $method:ident, $i2c_transactions:expr, $spi_transactions:expr, $( $value:expr ),+) => {
         mod $name {
             use super::*;
             _set_values_test!(
@@ -445,37 +559,36 @@ macro_rules! set_values_test {
                 $method,
                 new_ds3231,
                 destroy_ds3231,
-                $value1,
-                $value2,
-                $i2c_transactions
+                $i2c_transactions,
+                $($value),*
             );
             _set_values_test!(
                 can_set_ds3232,
                 $method,
                 new_ds3232,
                 destroy_ds3232,
-                $value1,
-                $value2,
-                $i2c_transactions
+                $i2c_transactions,
+                $($value),*
             );
             _set_values_test!(
                 can_set_ds3234,
                 $method,
                 new_ds3234,
                 destroy_ds3234,
-                $value1,
-                $value2,
-                $spi_transactions
+                $spi_transactions,
+                $($value),*
             );
         }
     };
 }
 
 macro_rules! set_alarm_test {
-    ($name:ident, $method:ident, $alarm:expr, $matching:expr, $register:ident, [ $( $registers:expr ),+ ]) => {
-        set_values_test!($name, $method, $alarm, $matching,
+    ($name:ident, $method:ident, $register:ident, [ $( $registers:expr ),+ ], $( $value:expr ),+) => {
+        set_values_test!($name, $method,
             [ I2cTrans::write(DEV_ADDR, vec![Register::$register, $( $registers ),*]) ],
-            [ SpiTrans::write(vec![Register::$register + 0x80, $( $registers ),*]) ]);
+            [ SpiTrans::write(vec![Register::$register + 0x80, $( $registers ),*]) ],
+            $($value),*
+        );
     };
 }
 
@@ -486,94 +599,146 @@ mod alarm1_day {
     set_alarm_test!(
         h24,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, 2, 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 2, 1]
+        A1M::AllMatch
     );
     set_alarm_test!(
         am,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, 0b0100_0010, 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::AM(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 0b0100_0010, 1]
+        A1M::AllMatch
     );
     set_alarm_test!(
         pm,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, 0b0110_0010, 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::PM(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 0b0110_0010, 1]
+        A1M::AllMatch
     );
 
     set_alarm_test!(
         match_hms,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, 2, AM | 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::HoursMinutesAndSecondsMatch,
+        A1M::HoursMinutesAndSecondsMatch
+    );
+    set_alarm_test!(
+        match_hms_ignore_incorrect_day,
+        set_alarm1_day,
         ALARM1_SECONDS,
-        [4, 3, 2, AM | 1]
+        [4, 3, 2, AM | 1],
+        DayAlarm1 {
+            day: 0,
+            hour: Hours::H24(2),
+            minute: 3,
+            second: 4
+        },
+        A1M::HoursMinutesAndSecondsMatch
+    );
+    set_alarm_test!(
+        match_ms_ignore_invalid_hour,
+        set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, AM | 0, AM | 1],
+        DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(24),
+            minute: 3,
+            second: 4
+        },
+        A1M::MinutesAndSecondsMatch
     );
     set_alarm_test!(
         match_ms,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, 3, AM | 2, AM | 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::MinutesAndSecondsMatch,
+        A1M::MinutesAndSecondsMatch
+    );
+    set_alarm_test!(
+        match_ms_ignore_incorrect_day,
+        set_alarm1_day,
         ALARM1_SECONDS,
-        [4, 3, AM | 2, AM | 1]
+        [4, 3, AM | 2, AM | 1],
+        DayAlarm1 {
+            day: 0,
+            hour: Hours::H24(2),
+            minute: 3,
+            second: 4
+        },
+        A1M::MinutesAndSecondsMatch
     );
     set_alarm_test!(
         match_s,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [4, AM | 3, AM | 2, AM | 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::SecondsMatch,
+        A1M::SecondsMatch
+    );
+    set_alarm_test!(
+        match_s_ignore_incorrect_min,
+        set_alarm1_day,
         ALARM1_SECONDS,
-        [4, AM | 3, AM | 2, AM | 1]
+        [4, AM | 0, AM | 2, AM | 1],
+        DayAlarm1 {
+            day: 1,
+            hour: Hours::H24(2),
+            minute: 60,
+            second: 4
+        },
+        A1M::SecondsMatch
     );
     set_alarm_test!(
         match_ops,
         set_alarm1_day,
+        ALARM1_SECONDS,
+        [AM | 4, AM | 3, AM | 2, AM | 1],
         DayAlarm1 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::OncePerSecond,
-        ALARM1_SECONDS,
-        [AM | 4, AM | 3, AM | 2, AM | 1]
+        A1M::OncePerSecond
     );
 }
 
@@ -582,94 +747,132 @@ mod alarm1_weekday {
     set_alarm_test!(
         h24,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, 2, BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 2, BF::WEEKDAY | 1]
+        A1M::AllMatch
     );
     set_alarm_test!(
         am,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, 0b0100_0010, BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::AM(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 0b0100_0010, BF::WEEKDAY | 1]
+        A1M::AllMatch
     );
     set_alarm_test!(
         pm,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, 0b0110_0010, BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::PM(2),
             minute: 3,
             second: 4
         },
-        A1M::AllMatch,
-        ALARM1_SECONDS,
-        [4, 3, 0b0110_0010, BF::WEEKDAY | 1]
+        A1M::AllMatch
     );
-
+    set_alarm_test!(
+        match_hms_ignore_incorrect_wd,
+        set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, 2, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm1 {
+            weekday: 0,
+            hour: Hours::H24(2),
+            minute: 3,
+            second: 4
+        },
+        A1M::HoursMinutesAndSecondsMatch
+    );
     set_alarm_test!(
         match_hms,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::HoursMinutesAndSecondsMatch,
-        ALARM1_SECONDS,
-        [4, 3, 2, AM | BF::WEEKDAY | 1]
+        A1M::HoursMinutesAndSecondsMatch
     );
     set_alarm_test!(
         match_ms,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, 3, AM | 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::MinutesAndSecondsMatch,
-        ALARM1_SECONDS,
-        [4, 3, AM | 2, AM | BF::WEEKDAY | 1]
+        A1M::MinutesAndSecondsMatch
     );
     set_alarm_test!(
         match_s,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [4, AM | 3, AM | 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::SecondsMatch,
+        A1M::SecondsMatch
+    );
+    set_alarm_test!(
+        match_s_ignore_incorrect_min,
+        set_alarm1_weekday,
         ALARM1_SECONDS,
-        [4, AM | 3, AM | 2, AM | BF::WEEKDAY | 1]
+        [4, AM | 0, AM | 2, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm1 {
+            weekday: 1,
+            hour: Hours::H24(2),
+            minute: 60,
+            second: 4
+        },
+        A1M::SecondsMatch
     );
     set_alarm_test!(
         match_ops,
         set_alarm1_weekday,
+        ALARM1_SECONDS,
+        [AM | 4, AM | 3, AM | 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm1 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3,
             second: 4
         },
-        A1M::OncePerSecond,
+        A1M::OncePerSecond
+    );
+    set_alarm_test!(
+        match_ops_ignore_incorrect_sec,
+        set_alarm1_weekday,
         ALARM1_SECONDS,
-        [AM | 4, AM | 3, AM | 2, AM | BF::WEEKDAY | 1]
+        [AM | 0, AM | 3, AM | 2, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm1 {
+            weekday: 1,
+            hour: Hours::H24(2),
+            minute: 3,
+            second: 60
+        },
+        A1M::OncePerSecond
     );
 }
 
@@ -678,75 +881,111 @@ mod alarm2_day {
     set_alarm_test!(
         h24,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [3, 2, 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 2, 1]
+        A2M::AllMatch
     );
     set_alarm_test!(
         am,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [3, 0b0100_0010, 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::AM(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 0b0100_0010, 1]
+        A2M::AllMatch
     );
     set_alarm_test!(
         pm,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [3, 0b0110_0010, 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::PM(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 0b0110_0010, 1]
+        A2M::AllMatch
     );
 
     set_alarm_test!(
         match_hm,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [3, 2, AM | 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::HoursAndMinutesMatch,
+        A2M::HoursAndMinutesMatch
+    );
+    set_alarm_test!(
+        match_hm_ignore_incorrect_day,
+        set_alarm2_day,
         ALARM2_MINUTES,
-        [3, 2, AM | 1]
+        [3, 2, AM | 1],
+        DayAlarm2 {
+            day: 0,
+            hour: Hours::H24(2),
+            minute: 3
+        },
+        A2M::HoursAndMinutesMatch
     );
     set_alarm_test!(
         match_m,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [3, AM | 2, AM | 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::MinutesMatch,
+        A2M::MinutesMatch
+    );
+    set_alarm_test!(
+        match_m_ignore_invalid_h,
+        set_alarm2_day,
         ALARM2_MINUTES,
-        [3, AM | 2, AM | 1]
+        [3, AM | 0, AM | 1],
+        DayAlarm2 {
+            day: 1,
+            hour: Hours::H24(25),
+            minute: 3
+        },
+        A2M::MinutesMatch
     );
     set_alarm_test!(
         match_opm,
         set_alarm2_day,
+        ALARM2_MINUTES,
+        [AM | 3, AM | 2, AM | 1],
         DayAlarm2 {
             day: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::OncePerMinute,
+        A2M::OncePerMinute
+    );
+    set_alarm_test!(
+        match_opm_ignore_incorrect_min,
+        set_alarm2_day,
         ALARM2_MINUTES,
-        [AM | 3, AM | 2, AM | 1]
+        [AM | 0, AM | 2, AM | 1],
+        DayAlarm2 {
+            day: 1,
+            hour: Hours::H24(2),
+            minute: 60
+        },
+        A2M::OncePerMinute
     );
 }
 
@@ -755,74 +994,109 @@ mod alarm2_weekday {
     set_alarm_test!(
         h24,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [3, 2, BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 2, BF::WEEKDAY | 1]
+        A2M::AllMatch
     );
     set_alarm_test!(
         am,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [3, 0b0100_0010, BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::AM(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 0b0100_0010, BF::WEEKDAY | 1]
+        A2M::AllMatch
     );
     set_alarm_test!(
         pm,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [3, 0b0110_0010, BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::PM(2),
             minute: 3
         },
-        A2M::AllMatch,
-        ALARM2_MINUTES,
-        [3, 0b0110_0010, BF::WEEKDAY | 1]
+        A2M::AllMatch
     );
-
     set_alarm_test!(
         match_hm,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [3, 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::HoursAndMinutesMatch,
+        A2M::HoursAndMinutesMatch
+    );
+    set_alarm_test!(
+        match_hm_ignore_incorrect_wd,
+        set_alarm2_weekday,
         ALARM2_MINUTES,
-        [3, 2, AM | BF::WEEKDAY | 1]
+        [3, 2, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm2 {
+            weekday: 0,
+            hour: Hours::H24(2),
+            minute: 3
+        },
+        A2M::HoursAndMinutesMatch
     );
     set_alarm_test!(
         match_m,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [3, AM | 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::MinutesMatch,
+        A2M::MinutesMatch
+    );
+    set_alarm_test!(
+        match_m_ignore_invalid_hour,
+        set_alarm2_weekday,
         ALARM2_MINUTES,
-        [3, AM | 2, AM | BF::WEEKDAY | 1]
+        [3, AM | 0, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm2 {
+            weekday: 1,
+            hour: Hours::H24(24),
+            minute: 3
+        },
+        A2M::MinutesMatch
     );
     set_alarm_test!(
         match_opm,
         set_alarm2_weekday,
+        ALARM2_MINUTES,
+        [AM | 3, AM | 2, AM | BF::WEEKDAY | 1],
         WeekdayAlarm2 {
             weekday: 1,
             hour: Hours::H24(2),
             minute: 3
         },
-        A2M::OncePerMinute,
+        A2M::OncePerMinute
+    );
+    set_alarm_test!(
+        match_opm_ignore_incorrect_min,
+        set_alarm2_weekday,
         ALARM2_MINUTES,
-        [AM | 3, AM | 2, AM | BF::WEEKDAY | 1]
+        [AM | 0, AM | 2, AM | BF::WEEKDAY | 1],
+        WeekdayAlarm2 {
+            weekday: 1,
+            hour: Hours::H24(2),
+            minute: 60
+        },
+        A2M::OncePerMinute
     );
 }


### PR DESCRIPTION
I needed to be able to use NaiveTime object for setting alarms. Also, it looks like the input checks for setting alarms were a bit too strict for some matching values.