### PR TITLE
Correct day bounds

### DIFF
--- a/src/ds323x/datetime.rs
+++ b/src/ds323x/datetime.rs
@@ -137,7 +137,7 @@ where
     }
 
     fn set_day(&mut self, day: u8) -> Result<(), Self::Error> {
-        if day < 1 || day > 7 {
+        if day < 1 || day > 31 {
             return Err(Error::InvalidInputData);
         }
         self.iface.write_register(Register::DOM, day)

--- a/tests/datetime.rs
+++ b/tests/datetime.rs
@@ -157,7 +157,7 @@ mod day {
     use super::*;
     get_param_test!(get, get_day, DOM, 1, 1);
     set_param_test!(set, set_day, DOM, 1, 1);
-    set_invalid_param_range_test!(invalid, set_day, 0, 8);
+    set_invalid_param_range_test!(invalid, set_day, 0, 32);
 }
 
 mod month {


### PR DESCRIPTION
Hey! I ran into this issue, it looks like the bounds checking for the day (of the month) was copy/pasted incorrectly from the other day (of the week) check.

This changes the bound checking to 31, instead of 8. Tests pass locally, let me know if there are any other things to update for this!