### PR TITLE
fix set_day method

### DIFF
--- a/src/ds323x/datetime.rs
+++ b/src/ds323x/datetime.rs
@@ -160,7 +160,7 @@ where
         if !(1..=31).contains(&day) {
             return Err(Error::InvalidInputData);
         }
-        self.iface.write_register(Register::DOM, day)
+        self.write_register_decimal(Register::DOM, day)
     }
 
     fn set_month(&mut self, month: u8) -> Result<(), Self::Error> {


### PR DESCRIPTION
The method receives in decimal the value to be set as the day of the month, but the ds3231 module expects it in bcd format.  
Using the `write_register_decimal` method, can be written in the correct format.