### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 rtcc = "0.3"
 
 [dev-dependencies]
-embedded-hal-mock = "0.9.0"
-linux-embedded-hal = "0.3.2"
+embedded-hal-mock = { version = "0.11.0", features = ["eh1"] }
+linux-embedded-hal = "0.4.0"
 
 [profile.release]
 lto = true

--- a/src/ds3231.rs
+++ b/src/ds3231.rs
@@ -2,11 +2,11 @@
 
 use crate::{ic, interface::I2cInterface, BitFlags, Ds323x, CONTROL_POR_VALUE};
 use core::marker::PhantomData;
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl<I2C, E> Ds323x<I2cInterface<I2C>, ic::DS3231>
 where
-    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Create a new instance of the DS3231 device.
     pub fn new_ds3231(i2c: I2C) -> Self {

--- a/src/ds3232.rs
+++ b/src/ds3232.rs
@@ -4,11 +4,11 @@ use crate::{
     ic, interface::I2cInterface, BitFlags, Ds323x, Error, TempConvRate, CONTROL_POR_VALUE,
 };
 use core::marker::PhantomData;
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl<I2C, E> Ds323x<I2cInterface<I2C>, ic::DS3232>
 where
-    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Create a new instance of the DS3232 device.
     pub fn new_ds3232(i2c: I2C) -> Self {

--- a/src/ds3234.rs
+++ b/src/ds3234.rs
@@ -2,11 +2,11 @@
 use crate::interface::{SpiInterface, WriteData};
 use crate::{ic, BitFlags, Ds323x, Error, Register, TempConvRate, CONTROL_POR_VALUE};
 use core::marker::PhantomData;
-use embedded_hal::{blocking::spi, digital::v2::OutputPin};
+use embedded_hal::{spi, digital::OutputPin};
 
 impl<SPI, CS, CommE, PinE> Ds323x<SpiInterface<SPI, CS>, ic::DS3234>
 where
-    SPI: spi::Transfer<u8, Error = CommE> + spi::Write<u8, Error = CommE>,
+    SPI: spi::SpiDevice<u8, Error = CommE>,
     CS: OutputPin<Error = PinE>,
 {
     /// Create a new instance.

--- a/tests/alarms.rs
+++ b/tests/alarms.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
+use embedded_hal_mock::eh1::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
 mod common;
 use self::common::{
     destroy_ds3231, destroy_ds3232, destroy_ds3234, new_ds3231, new_ds3232, new_ds3234,
@@ -583,7 +583,7 @@ macro_rules! set_alarm_test {
     ($name:ident, $method:ident, $register:ident, [ $( $registers:expr ),+ ], $( $value:expr ),+) => {
         set_values_test!($name, $method,
             [ I2cTrans::write(DEV_ADDR, vec![Register::$register, $( $registers ),*]) ],
-            [ SpiTrans::write(vec![Register::$register + 0x80, $( $registers ),*]) ],
+            [ SpiTrans::write_vec(vec![Register::$register + 0x80, $( $registers ),*]) ],
             $($value),*
         );
     };

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -1,5 +1,5 @@
 use ds323x::SqWFreq;
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
+use embedded_hal_mock::eh1::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
 
 mod common;
 use self::common::{
@@ -46,7 +46,7 @@ macro_rules! call_method_test {
                 DEV_ADDR,
                 vec![Register::$register, $value_enabled]
             )],
-            [SpiTrans::write(vec![
+            [SpiTrans::write_vec(vec![
                 Register::$register + 0x80,
                 $value_enabled
             ])]
@@ -83,7 +83,7 @@ macro_rules! call_method_status_test {
                 $method,
                 new_ds3234,
                 destroy_ds3234,
-                [SpiTrans::write(vec![
+                [SpiTrans::write_vec(vec![
                     Register::STATUS + 0x80,
                     $value_ds323x
                 ])]
@@ -126,7 +126,7 @@ macro_rules! change_if_necessary_test {
                         vec![Register::$register, 0],
                         vec![Register::$register, $value_disabled]
                     ),
-                    SpiTrans::write(vec![Register::$register + 0x80, $value_enabled])
+                    SpiTrans::write_vec(vec![Register::$register + 0x80, $value_enabled])
                 ]
             );
         }

--- a/tests/datetime.rs
+++ b/tests/datetime.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
+use embedded_hal_mock::eh1::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
 use rtcc::NaiveDateTime;
 mod common;
 use self::common::{
@@ -39,7 +39,7 @@ macro_rules! read_set_param_write_two_test {
                     vec![Register::$register, 0],
                     vec![Register::$register, $binary_value1_read]
                 ),
-                SpiTrans::write(vec![Register::$register + 0x80, $bin1, $bin2])
+                SpiTrans::write_vec(vec![Register::$register + 0x80, $bin1, $bin2])
             ]
         );
     };
@@ -64,7 +64,7 @@ macro_rules! read_set_param_test {
                     vec![Register::$register, 0],
                     vec![Register::$register, $binary_value_read]
                 ),
-                SpiTrans::write(vec![Register::$register + 0x80, $binary_value_write])
+                SpiTrans::write_vec(vec![Register::$register + 0x80, $binary_value_write])
             ]
         );
     };
@@ -256,7 +256,7 @@ macro_rules! transactions_i2c_write {
 
 macro_rules! transactions_spi_write {
     ($register:ident, [ $( $exp_bin:expr ),+ ]) => {
-            [ SpiTrans::write(vec![Register::$register + 0x80, $( $exp_bin ),*]) ]
+            [ SpiTrans::write_vec(vec![Register::$register + 0x80, $( $exp_bin ),*]) ]
     };
 }
 

--- a/tests/ds3232_4.rs
+++ b/tests/ds3232_4.rs
@@ -1,5 +1,5 @@
 use ds323x::TempConvRate;
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
+use embedded_hal_mock::eh1::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
 
 #[allow(unused)]
 mod common;
@@ -24,7 +24,7 @@ macro_rules! call_method_status_test {
                 $method,
                 new_ds3234,
                 destroy_ds3234,
-                [SpiTrans::write(vec![Register::STATUS + 0x80, $value])]
+                [SpiTrans::write_vec(vec![Register::STATUS + 0x80, $value])]
             );
         }
     };
@@ -66,7 +66,7 @@ macro_rules! set_param_test_2_4 {
                 DEV_ADDR,
                 vec![Register::$register, $binary_value]
             )],
-            [SpiTrans::write(vec![
+            [SpiTrans::write_vec(vec![
                 Register::$register + 0x80,
                 $binary_value
             ])]

--- a/tests/ds3234.rs
+++ b/tests/ds3234.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::spi::Transaction as SpiTrans;
+use embedded_hal_mock::eh1::spi::Transaction as SpiTrans;
 
 #[allow(unused)]
 mod common;
@@ -9,7 +9,7 @@ call_test!(
     enable_temperature_conversions_on_battery,
     new_ds3234,
     destroy_ds3234,
-    [SpiTrans::write(vec![Register::TEMP_CONV + 0x80, 0])]
+    [SpiTrans::write_vec(vec![Register::TEMP_CONV + 0x80, 0])]
 );
 
 call_test!(
@@ -17,7 +17,7 @@ call_test!(
     disable_temperature_conversions_on_battery,
     new_ds3234,
     destroy_ds3234,
-    [SpiTrans::write(vec![
+    [SpiTrans::write_vec(vec![
         Register::TEMP_CONV + 0x80,
         BitFlags::TEMP_CONV_BAT
     ])]

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
+use embedded_hal_mock::eh1::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
 mod common;
 use self::common::{
     destroy_ds3231, destroy_ds3232, destroy_ds3234, new_ds3231, new_ds3232, new_ds3234,


### PR DESCRIPTION
Hi!
This updates to `embedded-hal 1.0.0`. A few changes are needed and a good chunk of the tests are still passing, however a few are failing. Maybe someone else can have a look, only the `ds3234` tests are failing, seems to be related to SPI.