### PR TITLE
Add optional support for defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 edition = "2018"
 
 [features]
-defmt = ["dep:defmt", "rtcc/defmt"]
+defmt-03 = ["dep:defmt", "rtcc/defmt-03"]
 
 [dependencies]
 embedded-hal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,13 @@ include = [
 ]
 edition = "2018"
 
+[features]
+defmt = ["dep:defmt", "rtcc/defmt"]
+
 [dependencies]
 embedded-hal = "1.0.0"
 rtcc = "0.3"
+defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["eh1"] }

--- a/src/ds323x/alarms.rs
+++ b/src/ds323x/alarms.rs
@@ -15,7 +15,7 @@ use crate::{
 /// - Second, minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct DayAlarm1 {
     /// Day of the month [1-31]
     pub day: u8,
@@ -35,7 +35,7 @@ pub struct DayAlarm1 {
 /// - Second, minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct WeekdayAlarm1 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -49,7 +49,7 @@ pub struct WeekdayAlarm1 {
 
 /// Alarm1 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Alarm1Matching {
     /// Alarm once per second.
     OncePerSecond,
@@ -71,7 +71,7 @@ pub enum Alarm1Matching {
 /// - Minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct DayAlarm2 {
     /// Day of month [1-31]
     pub day: u8,
@@ -89,7 +89,7 @@ pub struct DayAlarm2 {
 /// - Minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct WeekdayAlarm2 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -101,7 +101,7 @@ pub struct WeekdayAlarm2 {
 
 /// Alarm2 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Alarm2Matching {
     /// Alarm once per minute. (00 seconds of every minute)
     OncePerMinute,

--- a/src/ds323x/alarms.rs
+++ b/src/ds323x/alarms.rs
@@ -15,6 +15,7 @@ use crate::{
 /// - Second, minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DayAlarm1 {
     /// Day of the month [1-31]
     pub day: u8,
@@ -34,6 +35,7 @@ pub struct DayAlarm1 {
 /// - Second, minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WeekdayAlarm1 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -47,6 +49,7 @@ pub struct WeekdayAlarm1 {
 
 /// Alarm1 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Alarm1Matching {
     /// Alarm once per second.
     OncePerSecond,
@@ -68,6 +71,7 @@ pub enum Alarm1Matching {
 /// - Minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DayAlarm2 {
     /// Day of month [1-31]
     pub day: u8,
@@ -85,6 +89,7 @@ pub struct DayAlarm2 {
 /// - Minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WeekdayAlarm2 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -96,6 +101,7 @@ pub struct WeekdayAlarm2 {
 
 /// Alarm2 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Alarm2Matching {
     /// Alarm once per minute. (00 seconds of every minute)
     OncePerMinute,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,12 +5,14 @@ use embedded_hal::{i2c, spi};
 
 /// I2C interface
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2cInterface<I2C> {
     pub(crate) i2c: I2C,
 }
 
 /// SPI interface
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SpiInterface<SPI> {
     pub(crate) spi: SPI,
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,14 +5,14 @@ use embedded_hal::{i2c, spi};
 
 /// I2C interface
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct I2cInterface<I2C> {
     pub(crate) i2c: I2C,
 }
 
 /// SPI interface
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct SpiInterface<SPI> {
     pub(crate) spi: SPI,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ pub const SPI_MODE_3: Mode = MODE_3;
 
 /// All possible errors in this crate
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<E> {
     /// I²C/SPI bus error
     Comm(E),
@@ -391,6 +392,7 @@ pub enum Error<E> {
 
 /// Square-wave output frequency
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SqWFreq {
     /// 1 Hz (default)
     _1Hz,
@@ -406,6 +408,7 @@ pub enum SqWFreq {
 ///
 /// This is only available on the DS3232 and DS3234 devices.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TempConvRate {
     /// Once every 64 seconds (default)
     _64s,
@@ -478,6 +481,7 @@ pub mod ic {
 
 /// DS3231, DS3232 and DS3234 RTC driver
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Ds323x<DI, IC> {
     iface: DI,
     control: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ pub const SPI_MODE_3: Mode = MODE_3;
 
 /// All possible errors in this crate
 #[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error<E> {
     /// I²C/SPI bus error
     Comm(E),
@@ -392,7 +392,7 @@ pub enum Error<E> {
 
 /// Square-wave output frequency
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum SqWFreq {
     /// 1 Hz (default)
     _1Hz,
@@ -408,7 +408,7 @@ pub enum SqWFreq {
 ///
 /// This is only available on the DS3232 and DS3234 devices.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum TempConvRate {
     /// Once every 64 seconds (default)
     _64s,
@@ -481,7 +481,7 @@ pub mod ic {
 
 /// DS3231, DS3232 and DS3234 RTC driver
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Ds323x<DI, IC> {
     iface: DI,
     control: u8,


### PR DESCRIPTION
This adds support for defmt::Format on some types. Needs eldruin/rtcc-rs#3.