### PR TITLE
Add defmt support behind the feature flag defmt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added defmt support behind a feature flag.
+
+### Changed
+
+- Updated `rtcc` to version  0.4.0 because it has defmt support.
+
 ## [0.6.0] - 2025-01-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Updated `rtcc` to version  0.4.0 because it has defmt support.
+- Updated `rtcc` to version  0.4.0, which has `defmt` support.
 
 ## [0.6.0] - 2025-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added defmt support behind a feature flag.
+- Added `defmt` support behind a feature flag.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ defmt = ["dep:defmt", "rtcc/defmt"]
 
 [dependencies]
 embedded-hal = "1.0.0"
-rtcc = "0.3"
+rtcc = "0.4"
 defmt = { version = "1.0.1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,13 @@ include = [
 ]
 edition = "2018"
 
+[features]
+defmt = ["dep:defmt", "rtcc/defmt"]
+
 [dependencies]
 embedded-hal = "1.0.0"
 rtcc = "0.3"
+defmt = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["eh1"] }

--- a/src/ds323x/alarms.rs
+++ b/src/ds323x/alarms.rs
@@ -15,6 +15,7 @@ use crate::{
 /// - Second, minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DayAlarm1 {
     /// Day of the month [1-31]
     pub day: u8,
@@ -34,6 +35,7 @@ pub struct DayAlarm1 {
 /// - Second, minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WeekdayAlarm1 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -47,6 +49,7 @@ pub struct WeekdayAlarm1 {
 
 /// Alarm1 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Alarm1Matching {
     /// Alarm once per second.
     OncePerSecond,
@@ -68,6 +71,7 @@ pub enum Alarm1Matching {
 /// - Minute and hour: 0
 /// - Day: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DayAlarm2 {
     /// Day of month [1-31]
     pub day: u8,
@@ -85,6 +89,7 @@ pub struct DayAlarm2 {
 /// - Minute and hour: 0
 /// - Weekday: 1
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WeekdayAlarm2 {
     /// Weekday [1-7]
     pub weekday: u8,
@@ -96,6 +101,7 @@ pub struct WeekdayAlarm2 {
 
 /// Alarm2 trigger rate
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Alarm2Matching {
     /// Alarm once per minute. (00 seconds of every minute)
     OncePerMinute,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,12 +5,14 @@ use embedded_hal::{i2c, spi};
 
 /// I2C interface
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2cInterface<I2C> {
     pub(crate) i2c: I2C,
 }
 
 /// SPI interface
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SpiInterface<SPI> {
     pub(crate) spi: SPI,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ pub const SPI_MODE_3: Mode = MODE_3;
 
 /// All possible errors in this crate
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<E> {
     /// I²C/SPI bus error
     Comm(E),
@@ -391,6 +392,7 @@ pub enum Error<E> {
 
 /// Square-wave output frequency
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SqWFreq {
     /// 1 Hz (default)
     _1Hz,
@@ -406,6 +408,7 @@ pub enum SqWFreq {
 ///
 /// This is only available on the DS3232 and DS3234 devices.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TempConvRate {
     /// Once every 64 seconds (default)
     _64s,
@@ -478,6 +481,7 @@ pub mod ic {
 
 /// DS3231, DS3232 and DS3234 RTC driver
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Ds323x<DI, IC> {
     iface: DI,
     control: u8,


### PR DESCRIPTION
This is DBLouis's work. I just updated the defmt to the stable 1.x version.

I felt it was time for this to be included now that defmt has reached 1.x. Also, 1.x is compatible with non-ancient version 0.3.x versions.