### PR TITLE
Fix century range check.

### DIFF
--- a/src/ds323x/datetime.rs
+++ b/src/ds323x/datetime.rs
@@ -36,7 +36,7 @@ where
     }
 
     fn set_datetime(&mut self, datetime: &NaiveDateTime) -> Result<(), Self::Error> {
-        if datetime.year() < 2000 || datetime.year() > 2100 {
+        if !(2000..=2199).contains(&datetime.year()) {
             return Err(Error::InvalidInputData);
         }
         let (month, year) = month_year_to_registers(datetime.month() as u8, datetime.year() as u16);
@@ -174,7 +174,7 @@ where
     }
 
     fn set_year(&mut self, year: u16) -> Result<(), Self::Error> {
-        if !(2000..=2100).contains(&year) {
+        if !(2000..=2199).contains(&year) {
             return Err(Error::InvalidInputData);
         }
         let data = self.iface.read_register(Register::MONTH)?;
@@ -197,7 +197,7 @@ where
     }
 
     fn set_date(&mut self, date: &rtcc::NaiveDate) -> Result<(), Self::Error> {
-        if date.year() < 2000 || date.year() > 2100 {
+        if !(2000..=2199).contains(&date.year()) {
             return Err(Error::InvalidInputData);
         }
         let (month, year) = month_year_to_registers(date.month() as u8, date.year() as u16);

--- a/src/ds323x/datetime.rs
+++ b/src/ds323x/datetime.rs
@@ -36,7 +36,7 @@ where
     }
 
     fn set_datetime(&mut self, datetime: &NaiveDateTime) -> Result<(), Self::Error> {
-        if !(2000..=2199).contains(&datetime.year()) {
+        if datetime.year() < 2000 || datetime.year() > 2100 {
             return Err(Error::InvalidInputData);
         }
         let (month, year) = month_year_to_registers(datetime.month() as u8, datetime.year() as u16);
@@ -174,7 +174,7 @@ where
     }
 
     fn set_year(&mut self, year: u16) -> Result<(), Self::Error> {
-        if !(2000..=2199).contains(&year) {
+        if !(2000..=2100).contains(&year) {
             return Err(Error::InvalidInputData);
         }
         let data = self.iface.read_register(Register::MONTH)?;
@@ -197,7 +197,7 @@ where
     }
 
     fn set_date(&mut self, date: &rtcc::NaiveDate) -> Result<(), Self::Error> {
-        if !(2000..=2199).contains(&date.year()) {
+        if date.year() < 2000 || date.year() > 2100 {
             return Err(Error::InvalidInputData);
         }
         let (month, year) = month_year_to_registers(date.month() as u8, date.year() as u16);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,21 +57,6 @@ impl BitFlags {
     pub const WEEKDAY: u8 = 0b0100_0000;
 }
 
-pub struct DummyOutputPin;
-
-impl embedded_hal::digital::OutputPin for DummyOutputPin {
-    fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-}
-
-impl embedded_hal::digital::ErrorType for DummyOutputPin {
-    type Error = embedded_hal::digital::ErrorKind;
-}
-
 pub fn new_ds3231(
     transactions: &[I2cTrans],
 ) -> Ds323x<interface::I2cInterface<I2cMock>, ic::DS3231> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,6 +57,21 @@ impl BitFlags {
     pub const WEEKDAY: u8 = 0b0100_0000;
 }
 
+pub struct DummyOutputPin;
+
+impl embedded_hal::digital::OutputPin for DummyOutputPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl embedded_hal::digital::ErrorType for DummyOutputPin {
+    type Error = embedded_hal::digital::ErrorKind;
+}
+
 pub fn new_ds3231(
     transactions: &[I2cTrans],
 ) -> Ds323x<interface::I2cInterface<I2cMock>, ic::DS3231> {


### PR DESCRIPTION
I was looking at the code see what it would take to make the library be able to use either chrono or jiff. In the process, I found what I believe is an error in the century range check. Instead of checking that the century does not exceed 2199, it checks that the century does not exceed 2100. This pull request is to fix that error.