### PR TITLE
Limiting Years to 2000-2099

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [breaking-change] Return Error::InvalidInputData when attempting to set the year to something
+  outside of the range 2000-2099 because all chips have a problem with the year 2100 and beyond.
+- [breaking-change] Return Error::InvalidDeviceCentury when attempting to get a date and/or time value
+  and the the device's century bit is set because all chips have a problem withe year 2100 and beyond.
+
 ## [0.7.0] - 2025-10-11
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,11 @@ pub enum Error<E> {
     /// It was not possible to read a valid date and/or time.
     /// The device is probably missing initialization.
     InvalidDeviceState,
+    /// Device century is not the 20th century.
+    ///
+    /// The device does not produce valid dates for centuries
+    /// other than the 20th century.
+    InvalidDeviceCentury,
 }
 
 /// Square-wave output frequency

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,6 +23,7 @@ impl Register {
     pub const DOW: u8 = 0x03;
     pub const DOM: u8 = 0x04;
     pub const MONTH: u8 = 0x05;
+    pub const YEAR: u8 = 0x06;
     pub const ALARM1_SECONDS: u8 = 0x07;
     pub const ALARM2_MINUTES: u8 = 0x0B;
     pub const CONTROL: u8 = 0x0E;
@@ -36,6 +37,7 @@ pub struct BitFlags;
 
 #[allow(unused)]
 impl BitFlags {
+    pub const CENTURY: u8 = 0b1000_0000;
     pub const EOSC: u8 = 0b1000_0000;
     pub const BBSQW: u8 = 0b0100_0000;
     pub const TEMP_CONV: u8 = 0b0010_0000;
@@ -124,12 +126,35 @@ macro_rules! assert_invalid_input_data {
 }
 
 #[macro_export]
+macro_rules! assert_invalid_device_century {
+    ($result:expr) => {
+        match $result {
+            Err(Error::InvalidDeviceCentury) => (),
+            _ => panic!("InvalidDeviceCentury error not returned."),
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! set_invalid_test {
     ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $value:expr) => {
         #[test]
         fn $name() {
             let mut dev = $create_method(&[]);
             assert_invalid_input_data!(dev.$method($value));
+            $destroy_method(dev);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! get_invalid_test {
+    ($name:ident, $method:ident, $create_method:ident, $destroy_method:ident, $transactions:expr) => {
+        #[test]
+        fn $name() {
+            let trans = $transactions;
+            let mut dev = $create_method(&trans);
+            assert_invalid_device_century!(dev.$method());
             $destroy_method(dev);
         }
     };


### PR DESCRIPTION
I have taken a stab at limiting the years to between 2000-2099. Set functions return an error when the year is not between 2000 and 2099. In addition, get functions that read the month (and therefore the CENTURY bit) return an error when the CENTURY bit is set. I updated tests accordingly. I did not return errors for functions that don't already read the month because I could not figure out out to update the tests for the functions when the function does two reads, one to read the month and one to read the values returned by the function.